### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ovos-workshop>=8.0.0,<9.0.0
+ovos-workshop>=8.0.0,<10.0.0


### PR DESCRIPTION
Lift the `ovos-workshop` upper bound from `<9.0.0` to `<10.0.0` in `requirements.txt` so this fixture skill can be installed alongside ovos-workshop 9.x.

This fixture skill is driven by the ovos-core ovoscope end-to-end suite. The old `<9.0.0` cap forces pip to downgrade ovos-workshop during the e2e install, which silences the workshop 9.x INTENT-4 producer's bus messages and makes the suite under-count. Lower bound is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)