### PR TITLE
fix(ci): add ovoscope e2e test + split test/end2end extras

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -11,5 +11,6 @@ jobs:
     secrets: inherit
     with:
       python_version: '3.11'
-      install_extras: 'test'
+      install_extras: 'end2end'
       test_path: 'test/end2end/'
+      require_padatious: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 recursive-include locale *
 recursive-include gui *
 include *.txt
+include requirements.txt
+include test/requirements.txt
+include test/requirements-end2end.txt

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,15 @@ setup(
     packages=[SKILL_PKG],
     include_package_data=True,
     install_requires=required("requirements.txt"),
+    extras_require={
+        # lightweight extra for unit tests (build_tests / coverage) — must NOT
+        # pull the heavy e2e stack so those jobs stay green without system deps
+        "test": required("test/requirements.txt"),
+        # heavy extra for ovoscope end-to-end tests (ovos-core[plugins,lgpl]
+        # drags in fann2 which needs swig + libfann system headers; the
+        # ovoscope job apt-installs them via require_padatious: true)
+        "end2end": required("test/requirements-end2end.txt"),
+    },
     keywords='ovos skill plugin',
     entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest collection config for the test suite.
+
+The ``test/end2end/`` suite is an ovoscope-driven end-to-end suite that requires
+the heavy e2e stack (``ovoscope`` + ``ovos-core[plugins,lgpl]``, which needs
+swig/libfann system headers). It is exercised by the dedicated ``ovoscope`` CI
+job (``install_extras: 'end2end'`` + ``require_padatious: true``).
+
+The lightweight ``build_tests``/``coverage`` jobs install only the ``test``
+extra and scan the whole ``test/`` tree, so without ovoscope present pytest
+would error out trying to import the end2end modules. When ovoscope is not
+installed we skip collecting that directory entirely so those jobs stay green.
+When ovoscope IS installed (the ovoscope job) the directory is collected and the
+e2e tests actually run.
+"""
+from importlib.util import find_spec
+
+collect_ignore_glob = []
+
+if find_spec("ovoscope") is None:
+    collect_ignore_glob.append("end2end/*")

--- a/test/end2end/test_parrot.py
+++ b/test/end2end/test_parrot.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_utils.log import LOG
+
+from ovoscope import End2EndTest, get_minicroft
+
+
+class TestParrotSkill(TestCase):
+
+    def setUp(self):
+        LOG.set_level("DEBUG")
+        self.skill_id = "ovos-skill-parrot.openvoiceos"
+        self.minicroft = get_minicroft([self.skill_id])
+        # the spoken message echoes the (randomised / slot-extracted) sentence
+        # and, on stacks with the bus-namespace migration enabled, is emitted
+        # under the ovos.* namespace ("ovos.utterance.speak") instead of
+        # "speak". Ignore both so the test asserts only the deterministic
+        # message-flow skeleton and is robust to slot extraction + namespace.
+        self.ignore_messages = ["speak", "ovos.utterance.speak"]
+
+    def tearDown(self):
+        if self.minicroft:
+            self.minicroft.stop()
+        LOG.set_level("CRITICAL")
+
+    def test_speak_intent(self):
+        """`say hello world` -> speak.intent -> handle_speak -> self.speak(...)
+
+        We assert the skeleton (utterance -> activate -> intent -> handler
+        start/complete -> handled) and ignore the speak message itself, because
+        the echoed text and its bus namespace vary across stacks.
+        """
+        session = Session("123")
+        session.pipeline = ["ovos-padatious-pipeline-plugin-high"]
+
+        message = Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["say hello world"], "lang": "en-US"},
+            {"session": session.serialize()},
+        )
+
+        expected_messages = [
+            message,
+            Message(f"{self.skill_id}.activate", {}),  # skill is activated
+            Message(f"{self.skill_id}:speak.intent", {}),  # intent triggers
+            Message("mycroft.skill.handler.start",
+                    {"name": "ParrotSkill.handle_speak"}),
+            # here the skill emits the echoed sentence via speak(...), ignored
+            Message("mycroft.skill.handler.complete",
+                    {"name": "ParrotSkill.handle_speak"}),
+            Message("ovos.utterance.handled", {}),
+        ]
+
+        test = End2EndTest(
+            minicroft=self.minicroft,
+            skill_ids=[],
+            eof_msgs=["ovos.utterance.handled"],
+            flip_points=["recognizer_loop:utterance"],
+            ignore_messages=self.ignore_messages,
+            source_message=message,
+            expected_messages=expected_messages,
+        )
+
+        test.execute()

--- a/test/requirements-end2end.txt
+++ b/test/requirements-end2end.txt
@@ -1,0 +1,3 @@
+ovoscope>=1.0.0a1,<2.0.0
+ovos-bus-client
+ovos-core[plugins,lgpl]>=2.0.0a1

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=5.2.4
+pytest-cov>=2.8.1


### PR DESCRIPTION
## Why

After #104 ("allow ovos-workshop 9.x") merged, the `ovoscope` check is still RED on `dev`: `test_path: 'test/end2end/'` does not exist, so 0 tests are collected and the job hard-fails (`exit 1`). build_tests + coverage are green and must stay green.

## What

- **setup.py**: add two extras. A lightweight `test` extra (pytest, pytest-cov) for build_tests/coverage, and a heavy `end2end` extra (ovoscope, ovos-bus-client, ovos-core[plugins,lgpl]) for the ovoscope job. Keeping the heavy e2e stack out of `test` keeps build_tests/coverage green without needing swig/libfann system headers.
- **test/requirements.txt** + **test/requirements-end2end.txt**: back the two extras.
- **MANIFEST.in**: ship `requirements.txt` + both test requirement files so the sdist build (which reads them at build time via `required(...)`) does not `FileNotFoundError`.
- **test/end2end/test_parrot.py**: deterministic ovoscope e2e test driving `speak.intent` ("say hello world") → `handle_speak`. Asserts the message-flow skeleton (utterance → activate → intent → handler start/complete → `ovos.utterance.handled`) and ignores the speak message (echoed/randomised text + `ovos.*` namespace under the bus-namespace migration).
- **test/conftest.py**: `collect_ignore` the end2end dir when ovoscope is not installed, so the lightweight build_tests/coverage jobs (which scan all of `test/`) do not error importing the e2e suite. The ovoscope job has ovoscope installed and runs the e2e test.
- **ovoscope.yml**: `install_extras: 'end2end'` + `require_padatious: true` (the job apt-installs libfann for padatious).

## Local verification

- `.[test]` install stays lightweight (no fann2/ovoscope/ovos-core); 5 unit tests pass; end2end not collected.
- `.[end2end]` resolves the heavy stack (ovos-core 2.2.1a1, ovos-bus-client 2.3.0a2, ovos-workshop 8.3.0a1, ovoscope 1.0.1a1, padatious + fann2); the e2e test passes (1 passed).
- `python -m build --sdist` succeeds and ships all three requirement files.

Note: `ovos-core[plugins,lgpl]` caps `ovos-workshop<9.0.0`, so the e2e stack resolves ovos-workshop to 8.3.x — this is expected and orthogonal to the skill's own `<10.0.0` ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)