### PR TITLE
fix: repeat_tts/repeat_stt raise KeyError after correct dispatch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,14 +30,23 @@ class ParrotSkill(ConversationalSkill):
         self.add_event('recognizer_loop:utterance', self.on_utterance)
         self.add_event('speak', self.on_speak)
 
+    @staticmethod
+    def _new_session_state():
+        # NOTE: "prev_stt"/"prev_tts" are included here (and default to "")
+        # so intent handlers can always index them once a session exists,
+        # regardless of whether on_utterance/on_speak has fired yet for it.
+        return {"current_stt": "",
+                "prev_stt": "",
+                "prev_tts": "",
+                "parrot": False,
+                "tts_timestamp": -1,
+                "stt_timestamp": -1}
+
     def on_utterance(self, message):
         utt = message.data['utterances'][0]
         sess = SessionManager.get(message)
         if sess.session_id not in self.parrot_sessions:
-            self.parrot_sessions[sess.session_id] = {"current_stt": "",
-                                                     "parrot": False,
-                                                     "tts_timestamp": -1,
-                                                     "stt_timestamp": -1}
+            self.parrot_sessions[sess.session_id] = self._new_session_state()
         self.parrot_sessions[sess.session_id]["prev_stt"] = self.parrot_sessions[sess.session_id]["current_stt"]
         self.parrot_sessions[sess.session_id]["current_stt"] = utt
         self.parrot_sessions[sess.session_id]["stt_timestamp"] = monotonic()
@@ -46,10 +55,7 @@ class ParrotSkill(ConversationalSkill):
         utt = message.data['utterance']
         sess = SessionManager.get(message)
         if sess.session_id not in self.parrot_sessions:
-            self.parrot_sessions[sess.session_id] = {"current_stt": "",
-                                                     "parrot": False,
-                                                     "tts_timestamp": -1,
-                                                     "stt_timestamp": -1}
+            self.parrot_sessions[sess.session_id] = self._new_session_state()
         self.parrot_sessions[sess.session_id]["prev_tts"] = utt
         self.parrot_sessions[sess.session_id]["tts_timestamp"] = monotonic()
 
@@ -106,10 +112,7 @@ class ParrotSkill(ConversationalSkill):
     def handle_start_parrot_intent(self, message):
         sess = SessionManager.get(message)
         if sess.session_id not in self.parrot_sessions:
-            self.parrot_sessions[sess.session_id] = {"current_stt": "",
-                                                     "parrot": False,
-                                                     "tts_timestamp": -1,
-                                                     "stt_timestamp": -1}
+            self.parrot_sessions[sess.session_id] = self._new_session_state()
 
         self.parrot_sessions[sess.session_id]["parrot"] = True
         self.speak_dialog("parrot_start")

--- a/test/end2end/test_golden_utterances.py
+++ b/test/end2end/test_golden_utterances.py
@@ -126,6 +126,60 @@ class TestParrotGoldenUtterances(unittest.TestCase):
             )
             self.fail(f"{len(failures)}/{len(GOLDEN_ROWS)} golden utterances mis-routed:\n{details}")
 
+    def test_repeat_handlers_complete_without_error_on_fresh_session(self):
+        """Regression: repeat_tts/repeat_stt must not raise on a session that
+        has never had a prior ``speak`` (repeat_tts) / never mattered before
+        (repeat_stt) event recorded for it.
+
+        A brand-new session only gets its ``parrot_sessions`` entry from
+        ``on_utterance`` (fired for the very same ``recognizer_loop:utterance``
+        message that triggers the intent match), which never populated
+        ``prev_tts`` (only ``on_speak`` does that). Before the fix,
+        ``handle_repeat_tts`` indexed ``self.parrot_sessions[sid]["prev_tts"]``
+        directly and raised ``KeyError: 'prev_tts'`` after the intent had
+        already correctly matched and dispatched -- observable on the bus as
+        ``mycroft.skill.handler.error`` / ``ovos.intent.handler.error``
+        instead of a normal ``mycroft.skill.handler.complete``.
+        """
+        cases = [
+            ("Can you repeat that?", "repeat_tts"),
+            ("What did I just say?", "repeat_stt"),
+        ]
+        failures = []
+        for i, (text, intent_name) in enumerate(cases):
+            with self.subTest(utterance=text, intent_name=intent_name):
+                messages = self._capture(text, f"repeat-regression-{i}")
+                handler_name = f"ParrotSkill.handle_{intent_name}"
+
+                error_messages = [
+                    m for m in messages
+                    if m.msg_type in ("mycroft.skill.handler.error", "ovos.intent.handler.error")
+                ]
+                complete_messages = [
+                    m for m in messages
+                    if m.msg_type == "mycroft.skill.handler.complete"
+                    and m.data.get("name") == handler_name
+                ]
+                spoke = any(
+                    m.msg_type in ("speak", "ovos.utterance.speak") for m in messages
+                )
+
+                if error_messages:
+                    failures.append(
+                        f"{text!r} ({intent_name}): handler errored: "
+                        f"{[m.data for m in error_messages]}"
+                    )
+                elif not complete_messages:
+                    failures.append(
+                        f"{text!r} ({intent_name}): no {handler_name!r} "
+                        f"mycroft.skill.handler.complete observed"
+                    )
+                elif not spoke:
+                    failures.append(f"{text!r} ({intent_name}): handler never spoke")
+
+        if failures:
+            self.fail("repeat handler regression:\n" + "\n".join(f"  {f}" for f in failures))
+
     def test_negative_confusables_not_claimed(self):
         """Utterances belonging to other skills must not be claimed by parrot."""
         assert len(NEGATIVE_UTTERANCES) >= 5


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What

Fixes a bug flagged by `ovos-test-harness`'s fleet routing suite
(`test/skills_fleet/FINDINGS.md`, "Known execution bug found in passing"):
`repeat_tts`/`repeat_stt` intents matched and dispatched correctly, but
the handler then raised (`mycroft.skill.handler.error` /
`ovos.intent.handler.error` on the bus) before speaking.

## Root cause

`handle_repeat_tts` indexes `self.parrot_sessions[sid]["prev_tts"]`
directly. That key is only ever set by `on_speak`. A session's dict
is created by `on_utterance`, which fires for the very
`recognizer_loop:utterance` message that triggers the intent match —
so a session's first-ever "repeat that" request (no prior skill
speech in that session) hits a dict that exists but has no
`prev_tts` key, raising `KeyError: 'prev_tts'` after correct
dispatch. `handle_repeat_stt` / `handle_did_you_hear_me` have the
same structural gap for `prev_stt` (three separate session-dict
literals across `on_utterance`, `on_speak`, and
`handle_start_parrot_intent` never included `prev_stt`/`prev_tts`).

Reproduced locally with a fresh MiniCroft/CaptureSession against a
brand-new session id sending "Can you repeat that?":

```
File ".../ovos-skill-parrot/__init__.py", line 70, in handle_repeat_tts
    utt = self.parrot_sessions[sess.session_id]["prev_tts"]
KeyError: 'prev_tts'
```

## Fix

A shared `_new_session_state()` helper initializes `prev_stt`/`prev_tts`
(default `""`) alongside the other session fields at every creation
site, so the keys always exist together once a session dict exists.

## Test plan

- Added `test_repeat_handlers_complete_without_error_on_fresh_session`
  to `test/end2end/test_golden_utterances.py`: drives `repeat_tts` and
  `repeat_stt` through fresh MiniCroft sessions and asserts a clean
  `mycroft.skill.handler.complete` (no handler/intent error message)
  plus an actual spoken response.
- Verified the new test fails with `KeyError: 'prev_tts'` against the
  unfixed handler, and passes after the fix.
- Full local suite: `15 passed, 39 subtests passed` (`pytest test/`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of newly started sessions for speech repetition features.
  * Prevented errors when repeating recent speech-to-text or text-to-speech content in a fresh session.

* **Tests**
  * Added end-to-end coverage verifying successful completion events and speech output for repeat commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->